### PR TITLE
Fix operator name encoding error

### DIFF
--- a/transitflow/transitflow.py
+++ b/transitflow/transitflow.py
@@ -183,6 +183,7 @@ def animate_operators(operators, date):
     count = 1
 
     for i in operators:
+        i = unicode(i, 'utf-8')
         i = i.encode('utf-8')
         print i, count, "/", length
         try:


### PR DESCRIPTION
When trying to use transitflow with operators like [o-6fes-empresapublicadetransportesecirculação](https://transit.land/feed-registry/operators/o-6fes-empresapublicadetransportesecircula%C3%A7%C3%A3o) it fails with `'ascii' codec can't encode characters in position 42-43: ordinal not in range(128)` (running on macOS Sierra Terminal Version 2.7.3)

This PR converts operator name from `<type 'str'>` to `<type 'unicode'>` before trying to `encode` it.